### PR TITLE
Don't print empty attributes map in `XmlElement.toString()`

### DIFF
--- a/src/main/kotlin/xoxo/xoxo.kt
+++ b/src/main/kotlin/xoxo/xoxo.kt
@@ -38,8 +38,14 @@ class XmlElement internal constructor(private val element: Element) : XmlNode {
     val textContent: String
         get() = walk().filterIsInstance<XmlText>().joinToString("") { it.content }
 
-    override fun toString(): String {
-        return "<$name $attributes>"
+    override fun toString(): String = buildString {
+        append("<")
+        append(name)
+        if (attributes.isNotEmpty()) {
+            append(" ")
+            append(attributes.toString())
+        }
+        append(">")
     }
 }
 

--- a/src/test/kotlin/xoxo/XmlElementTest.kt
+++ b/src/test/kotlin/xoxo/XmlElementTest.kt
@@ -1,0 +1,31 @@
+package xoxo
+
+import org.intellij.lang.annotations.Language
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class XmlElementTest {
+
+    @Test
+    fun `toString with attributes`() {
+        @Language("XML")
+        val xml = """<root key1="value1" key2="value2"/>"""
+        val text = xml.toXmlDocument().root.walkElements().single()
+        assertEquals(
+            "<root {key1=value1, key2=value2}>",
+            text.toString()
+        )
+    }
+
+    @Test
+    fun `toString without attributes`() {
+        @Language("XML")
+        val xml = """<root/>"""
+        val text = xml.toXmlDocument().root.walkElements().single()
+        assertEquals(
+            "<root>",
+            text.toString()
+        )
+    }
+
+}


### PR DESCRIPTION
It's just a personal preference to not print the empty map.

You can refuse this, no worries :)