### PR TITLE
Replace current ordering with a more natural "Depth First"

### DIFF
--- a/src/main/kotlin/xoxo/xoxo.kt
+++ b/src/main/kotlin/xoxo/xoxo.kt
@@ -6,6 +6,7 @@ import okio.buffer
 import okio.source
 import org.w3c.dom.*
 import java.io.File
+import java.util.*
 import javax.xml.parsers.DocumentBuilderFactory
 
 sealed interface XmlNode {
@@ -89,14 +90,14 @@ fun String.toXmlDocument(): XmlDocument {
 }
 
 fun XmlNode.walk(): Sequence<XmlNode> {
-    val stack = mutableListOf<XmlNode>()
+    val stack: LinkedList<XmlNode> = LinkedList()
     stack.add(this)
     return generateSequence {
         if (stack.isEmpty()) {
             return@generateSequence null
         }
 
-        val element = stack.removeFirst()
+        val element = stack.pop()
         if (element is XmlElement) {
             stack.addAll(0, element.children)
         }

--- a/src/main/kotlin/xoxo/xoxo.kt
+++ b/src/main/kotlin/xoxo/xoxo.kt
@@ -98,7 +98,7 @@ fun XmlNode.walk(): Sequence<XmlNode> {
 
         val element = stack.removeFirst()
         if (element is XmlElement) {
-            stack.addAll(element.children)
+            stack.addAll(0, element.children)
         }
         element
     }

--- a/src/test/kotlin/xoxo/XmlNodeTest.kt
+++ b/src/test/kotlin/xoxo/XmlNodeTest.kt
@@ -1,0 +1,32 @@
+package xoxo
+
+import org.intellij.lang.annotations.Language
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class XmlNodeTest {
+
+    @Test
+    fun `walk nodes`() {
+        @Language("XML")
+        val xml = """<root><a>1</a><b><b1>2′</b1><b2>2″</b2><b3>2‴</b3></b><c>3</c></root>""".trimIndent()
+        val nodes = xml.toXmlDocument().root.walk().toList()
+        with(nodes.iterator()) {
+            assertEquals("root", (next() as XmlElement).name)
+            assertEquals("a", (next() as XmlElement).name)
+            assertEquals("1", (next() as XmlText).content)
+            assertEquals("b", (next() as XmlElement).name)
+            assertEquals("b1", (next() as XmlElement).name)
+            assertEquals("2′", (next() as XmlText).content)
+            assertEquals("b2", (next() as XmlElement).name)
+            assertEquals("2″", (next() as XmlText).content)
+            assertEquals("b3", (next() as XmlElement).name)
+            assertEquals("2‴", (next() as XmlText).content)
+            assertEquals("c", (next() as XmlElement).name)
+            assertEquals("3", (next() as XmlText).content)
+            assertFalse(hasNext())
+        }
+    }
+
+}


### PR DESCRIPTION
And replace MutableList with LinkedList.
Which is a tiny bit more performant for those LIFO stacks.
~40% faster on synthetic benchmark.