### PR TITLE
Remove unsafe `asElement` and `asText` dynamic getters

### DIFF
--- a/src/main/kotlin/xoxo/xoxo.kt
+++ b/src/main/kotlin/xoxo/xoxo.kt
@@ -8,13 +8,7 @@ import org.w3c.dom.*
 import java.io.File
 import javax.xml.parsers.DocumentBuilderFactory
 
-sealed interface XmlNode {
-    val asElement: XmlElement
-        get() = this as XmlElement
-
-    val asText: XmlText
-        get() = this as XmlText
-}
+sealed interface XmlNode
 
 private fun Node.toXmlNode(): XmlNode? {
     return when (this) {


### PR DESCRIPTION
These will crash if the object is not of the right type, and if we need to know the type to prevent crash, we can already do

```kotlin
fun test(node: XmlNode) {
    val element = node as? XmlElement
    val text = node as? XmlText
    TODO()
}
```

Instead, we _should_ encourage the _idiomatic_ usage of smart cast allowed by the sealed interface.

```kotlin
fun test(document: XmlDocument) {
    document.root.walk().map {
        when (it) {
            is XmlElement -> TODO()
            is XmlText -> TODO()
        }
    }
}
```

Unless you had something specific in mind for these extensions.