### PR TITLE
Expose `Node.toXmlNode()` as public API

### DIFF
--- a/src/main/kotlin/xoxo/xoxo.kt
+++ b/src/main/kotlin/xoxo/xoxo.kt
@@ -16,7 +16,7 @@ sealed interface XmlNode
  */
 inline fun <reified T : Any> Any?.cast(): T = this as T
 
-private fun Node.toXmlNode(): XmlNode? {
+fun Node.toXmlNode(): XmlNode? {
     return when (this) {
         is Element -> XmlElement(this)
         is Text -> XmlText(this)


### PR DESCRIPTION
Fixes #12