### PR TITLE
Reduce receiver scope for the inline `cast()` function

### DIFF
--- a/src/main/kotlin/xoxo/xoxo.kt
+++ b/src/main/kotlin/xoxo/xoxo.kt
@@ -12,9 +12,9 @@ import javax.xml.parsers.DocumentBuilderFactory
 sealed interface XmlNode
 
 /**
- * Helper function to cast a XMLNode to a XMLElement or XMLText
+ * Helper function to cast a [XmlNode] to a [XmlElement] or [XmlText]
  */
-inline fun <reified T : Any> Any?.cast(): T = this as T
+inline fun <reified T : XmlNode> XmlNode?.cast(): T = this as T
 
 fun Node.toXmlNode(): XmlNode? {
     return when (this) {


### PR DESCRIPTION
to avoid polluting the global namespace.
And fix javadoc references.